### PR TITLE
Long file name issue

### DIFF
--- a/FineCodeCoverage/Core/FileSynchronization/FileSynchronization.cs
+++ b/FineCodeCoverage/Core/FileSynchronization/FileSynchronization.cs
@@ -1,9 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.IO;
 using System.Linq;
 using FineCodeCoverage.Core.Utilities;
+using Directory = Alphaleonis.Win32.Filesystem.Directory;
+using DirectoryInfo = Alphaleonis.Win32.Filesystem.DirectoryInfo;
+using File = Alphaleonis.Win32.Filesystem.File;
+using FileInfo = Alphaleonis.Win32.Filesystem.FileInfo;
+using Path = Alphaleonis.Win32.Filesystem.Path;
 
 namespace FineCodeCoverage.Engine.FileSynchronization
 {
@@ -22,9 +26,14 @@ namespace FineCodeCoverage.Engine.FileSynchronization
 			var destDir = new DirectoryInfo(Path.GetFullPath(destinationFolder) + '\\');
 
 			// file lists
-			var sourceFileInfos = srceDir.GetFiles().Concat(srceDir.GetDirectories().Where(d => d.Name != fineCodeCoverageFolderName).SelectMany(d => d.GetFiles("*", SearchOption.AllDirectories)));
+			var sourceFileInfos = srceDir.GetFiles().Concat(srceDir.GetDirectories()
+                .Where(d => d.Name != fineCodeCoverageFolderName).SelectMany(d => d.GetFiles("*", System.IO.SearchOption.AllDirectories)));
+
+
 			var srceFiles = sourceFileInfos.AsParallel().Select(fi => new ComparableFile(fi, fi.FullName.Substring(srceDir.FullName.Length)));
-			ParallelQuery<ComparableFile> destFiles() => destDir.GetFiles("*", SearchOption.AllDirectories).AsParallel().Select(fi => new ComparableFile(fi, fi.FullName.Substring(destDir.FullName.Length)));
+			
+            
+            ParallelQuery<ComparableFile> destFiles() => destDir.GetFiles("*", System.IO.SearchOption.AllDirectories).AsParallel().Select(fi => new ComparableFile(fi, fi.FullName.Substring(destDir.FullName.Length)));
 
 			// copy to dest
 

--- a/FineCodeCoverage/Core/Utilities/ComparableFile.cs
+++ b/FineCodeCoverage/Core/Utilities/ComparableFile.cs
@@ -1,5 +1,6 @@
 ﻿using System;
-using System.IO;
+using Alphaleonis.Win32.Filesystem;
+
 
 namespace FineCodeCoverage.Core.Utilities
 {

--- a/FineCodeCoverage/FineCodeCoverage.csproj
+++ b/FineCodeCoverage/FineCodeCoverage.csproj
@@ -280,6 +280,9 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="AlphaFS">
+      <Version>2.2.6</Version>
+    </PackageReference>
     <PackageReference Include="CliWrap">
       <Version>3.2.2</Version>
     </PackageReference>


### PR DESCRIPTION
This commit fix the long file name error when accessing files with names longer than 248 characters.